### PR TITLE
fix: add bounds check in whad_phy_set_sync_word_parse() to prevent stack overflow

### DIFF
--- a/src/domains/phy.c
+++ b/src/domains/phy.c
@@ -809,6 +809,13 @@ whad_result_t whad_phy_set_sync_word_parse(Message *p_message, whad_phy_syncword
 
     /* Extract sync word from message. */
     p_syncword->length = p_message->msg.phy.msg.sync_word.sync_word.size;
+
+    /* Ensure the sync word does not exceed the destination buffer. */
+    if (p_syncword->length > sizeof(p_syncword->syncword))
+    {
+        return WHAD_ERROR;
+    }
+
     memcpy(p_syncword->syncword, p_message->msg.phy.msg.sync_word.sync_word.bytes, p_syncword->length);
 
     /* Success. */


### PR DESCRIPTION
## Summary

`whad_phy_set_sync_word_parse()` copies `sync_word.size` bytes from a
protobuf-decoded field into `p_syncword->syncword`, which is declared as
`uint8_t syncword[10]` in `whad_phy_syncword_t` (`inc/domains/phy.h:68`).
No bounds check is performed before the `memcpy`, so a message with
`sync_word.size > 10` causes a stack-buffer-overflow.

This is consistent with the bounds checks already present for packet
payloads in the same file (e.g. `p_packet->length < 256` at line 1067),
which were introduced in ab24e5f. The sync word parser was missed in that change.

## Impact

A crafted PHY SetSyncWord protobuf message with `sync_word.size` set to
any value greater than 10 overflows the 10-byte stack buffer by up to
117 bytes (NanoPb max field size), corrupting adjacent stack variables.
Confirmed via libFuzzer + AddressSanitizer:

```
ERROR: AddressSanitizer: stack-buffer-overflow
WRITE of size 127 at offset 1200 in frame LLVMFuzzerTestOneInput
    #0 __asan_memcpy
    #1 whad_phy_set_sync_word_parse  src/domains/phy.c:812
    #2 LLVMFuzzerTestOneInput
```

## Fix

Add a length check before the `memcpy`, mirroring the pattern used for
packet payloads. Returns `WHAD_ERROR` if the message specifies a sync
word longer than the destination buffer.