### PR TITLE
fix: add missing bounds check on address length in ESB and Unifying sniff parsers

### DIFF
--- a/src/domains/esb.c
+++ b/src/domains/esb.c
@@ -153,6 +153,10 @@ whad_result_t whad_esb_sniff_parse(Message *p_message, whad_esb_sniff_params_t *
         p_params->channel = p_message->msg.esb.msg.sniff.channel;
         p_params->show_acks = p_message->msg.esb.msg.sniff.show_acknowledgements;
         p_params->address.size = p_message->msg.esb.msg.sniff.address.size;
+        if (p_params->address.size > ESB_ADDR_MAX_SIZE)
+        {
+            return WHAD_ERROR;
+        }
         memcpy(p_params->address.address, p_message->msg.esb.msg.sniff.address.bytes, p_params->address.size);
 
         /* Success. */

--- a/src/domains/unifying.c
+++ b/src/domains/unifying.c
@@ -149,6 +149,10 @@ whad_result_t whad_unifying_sniff_parse(Message *p_message, whad_unifying_sniff_
     p_params->channel = p_message->msg.unifying.msg.sniff.channel;
     p_params->show_acks = p_message->msg.unifying.msg.sniff.show_acknowledgements;
     p_params->address.size = p_message->msg.unifying.msg.sniff.address.size;
+    if (p_params->address.size > UNIFYING_ADDR_MAX_SIZE)
+    {
+        return WHAD_ERROR;
+    }
     memcpy(p_params->address.address, p_message->msg.unifying.msg.sniff.address.bytes, p_params->address.size);
 
     /* Success. */


### PR DESCRIPTION
Hey,

While reviewing the parse functions I noticed that `whad_esb_sniff_parse()`
and `whad_unifying_sniff_parse()` copy the address field from the protobuf
message into a fixed-size buffer without checking the length first:

    p_params->address.size = p_message->...address.size;
    memcpy(p_params->address.address, ..., p_params->address.size);

Since `address.size` comes straight from the deserialized message with no
upper bound enforced by nanopb, a value larger than 5 overflows the
`address[ESB_ADDR_MAX_SIZE]` / `address[UNIFYING_ADDR_MAX_SIZE]` stack buffer.

The fix is just a length check before the memcpy, same pattern as what's
already done in `whad_dot15d4_send_parse()`.

Cheers