### PR TITLE
fix: add missing bounds check on PDU length in ESB and Unifying send parsers

### DIFF
--- a/src/domains/esb.c
+++ b/src/domains/esb.c
@@ -275,6 +275,10 @@ whad_result_t whad_esb_send_parse(Message *p_message, whad_esb_send_params_t *p_
     p_params->channel = p_message->msg.esb.msg.send.channel;
     p_params->retr_count = p_message->msg.esb.msg.send.retransmission_count;
     p_params->packet.length = p_message->msg.esb.msg.send.pdu.size;
+    if (p_params->packet.length > ESB_PACKET_MAX_SIZE)
+    {
+        return WHAD_ERROR;
+    }
     memcpy(p_params->packet.bytes, p_message->msg.esb.msg.send.pdu.bytes, p_message->msg.esb.msg.send.pdu.size);
 
     /* Success. */
@@ -340,6 +344,10 @@ whad_result_t whad_esb_send_raw_parse(Message *p_message, whad_esb_send_params_t
     p_params->channel = p_message->msg.esb.msg.send_raw.channel;
     p_params->retr_count = p_message->msg.esb.msg.send_raw.retransmission_count;
     p_params->packet.length = p_message->msg.esb.msg.send_raw.pdu.size;
+    if (p_params->packet.length > ESB_PACKET_MAX_SIZE)
+    {
+        return WHAD_ERROR;
+    }
     memcpy(p_params->packet.bytes, p_message->msg.esb.msg.send_raw.pdu.bytes, p_message->msg.esb.msg.send_raw.pdu.size);
 
     /* Success. */

--- a/src/domains/unifying.c
+++ b/src/domains/unifying.c
@@ -270,6 +270,10 @@ whad_result_t whad_unifying_send_parse(Message *p_message, whad_unifying_send_pa
     p_params->channel = p_message->msg.unifying.msg.send.channel;
     p_params->retr_count = p_message->msg.unifying.msg.send.retransmission_count;
     p_params->packet.length = p_message->msg.unifying.msg.send.pdu.size;
+    if (p_params->packet.length > UNIFYING_PACKET_MAX_SIZE)
+    {
+        return WHAD_ERROR;
+    }
     memcpy(p_params->packet.bytes, p_message->msg.unifying.msg.send.pdu.bytes, p_message->msg.unifying.msg.send.pdu.size);
 
     /* Success. */
@@ -335,6 +339,10 @@ whad_result_t whad_unifying_send_raw_parse(Message *p_message, whad_unifying_sen
     p_params->channel = p_message->msg.unifying.msg.send_raw.channel;
     p_params->retr_count = p_message->msg.unifying.msg.send_raw.retransmission_count;
     p_params->packet.length = p_message->msg.unifying.msg.send_raw.pdu.size;
+    if (p_params->packet.length > UNIFYING_PACKET_MAX_SIZE)
+    {
+        return WHAD_ERROR;
+    }
     memcpy(p_params->packet.bytes, p_message->msg.unifying.msg.send_raw.pdu.bytes, p_message->msg.unifying.msg.send_raw.pdu.size);
 
     /* Success. */


### PR DESCRIPTION
Hey,

Same class of issue as the previous PR but for the send-side parsers.
`whad_esb_send_parse()`, `whad_esb_send_raw_parse()`, `whad_unifying_send_parse()`
and `whad_unifying_send_raw_parse()` all do:

    p_params->packet.length = p_message->...pdu.size;
    memcpy(p_params->packet.bytes, ..., pdu.size);

`pdu.size` is attacker-controlled and nanopb doesn't cap it, so anything
above 255 overflows `packet.bytes[ESB_PACKET_MAX_SIZE]` on the stack.

Interestingly `whad_dot15d4_send_parse()` and `whad_dot15d4_send_raw_parse()`
already have the `> DOT15D4_PACKET_MAX_SIZE` guard — this PR just adds the
equivalent check to the four ESB/Unifying functions that were missed.

Cheers