### PR TITLE
ble: parse SetEncryption from the raw message

### DIFF
--- a/src/cpp/domains/ble/ble_set_encryption.cpp
+++ b/src/cpp/domains/ble/ble_set_encryption.cpp
@@ -61,8 +61,7 @@ void SetEncryption::unpack()
 {
     whad_ble_encryption_params_t params;
 
-    /* Parse SetEncryption message. */
-    if (whad_ble_set_encryption_parse(this->getRaw(), &params) == WHAD_SUCCESS)
+    if (whad_ble_set_encryption_parse(this->getMessage(), &params) == WHAD_SUCCESS)
     {
         this->m_connHandle = params.conn_handle;
         this->m_enabled = params.enabled;


### PR DESCRIPTION
Fixing a parsing error for the SetEncryption method, the butterfly firmware got a null-filled session key, only changing the getRaw() method for getMessage()